### PR TITLE
Fix wired mode regression caused by 3ee56ef

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -535,7 +535,7 @@ const USB_Descriptor_Device_t PROGMEM DeviceDescriptor = {
 /*
  * Configuration descriptors
  */
-const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor = {
+USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor = {
     .Config = {
         .Header = {
             .Size               = sizeof(USB_Descriptor_Configuration_Header_t),
@@ -1263,7 +1263,7 @@ const USB_Descriptor_String_t PROGMEM MsOsString = {
     .UnicodeString              = { 'M' ,'S' ,'F' ,'T' ,'1' ,'0' ,'0', USB_REQ_GET_MS_DESCRIPTOR }
 };
 
-const uint8_t PROGMEM compatIdDescriptor[] =
+PROGMEM uint8_t compatIdDescriptor[] =
 {
     0x28, 0x00, 0x00, 0x00,    // dwLength
     0x00, 0x01,                // bcdVersion: 1.00
@@ -1283,7 +1283,7 @@ const uint8_t PROGMEM compatIdDescriptor[] =
 //    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,              // reserved
 };
 
-const uint8_t PROGMEM extendedPropertiesDescriptor[0x92] =
+PROGMEM uint8_t extendedPropertiesDescriptor[0x92] =
 {
     0x92, 0x00, 0x00, 0x00,    // dwLength
     0x00, 0x01,                // bcdVersion: 1.00


### PR DESCRIPTION
<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
Tested on k2_he/iso with untouched vial keymap.

Previous change broke all wired connections, leaving only BT/2.4GHz. 
When DIP-switch is centered, connecting to USB makes the keyboard light up very momentarily and then shut off. No HID devices are detected, only the `USB Composite Device`. 