### PR TITLE
Unify OS LED handling, add timeout support

### DIFF
--- a/keyboards/keychron/c1_pro_8k/c1_pro_8k.c
+++ b/keyboards/keychron/c1_pro_8k/c1_pro_8k.c
@@ -26,7 +26,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_BASE_LAYER : WIN_BASE_LAYER));
     }
     return true;
 }
@@ -49,21 +49,17 @@ void keychron_task_kb(void) {
             power_on_indicator_timer = 0;
 
             if (!host_keyboard_led_state().caps_lock) gpio_write_pin(LED_CAPS_LOCK_PIN, !LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+
+#ifdef LED_OS_TIMEOUT
+            keychron_os_led_trigger();
+#endif
         } else {
             gpio_write_pin(LED_CAPS_LOCK_PIN, LED_OS_PIN_ON_STATE);
             gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
             gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
         }
     } else {
-        if (get_highest_layer(default_layer_state) == MAC_BASE_LAYER) {
-            gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-        } else {
-            gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-        }
+        keychron_os_led_process();
     }
 }
 

--- a/keyboards/keychron/c1_pro_v2/c1_pro_v2.c
+++ b/keyboards/keychron/c1_pro_v2/c1_pro_v2.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 #ifdef DIP_SWITCH_ENABLE
 bool dip_switch_update_kb(uint8_t index, bool active) {
@@ -22,7 +23,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_BASE_LAYER : WIN_BASE_LAYER));
     }
     return true;
 }
@@ -82,18 +83,15 @@ void keyboard_post_init_kb(void) {
     gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
     gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
 
+#ifdef LED_OS_TIMEOUT
+    keychron_os_led_trigger();
+#endif
+
     keyboard_post_init_user();
 }
 
 void housekeeping_task_kb(void) {
-    if (default_layer_state == (1U << 0)) {
-        gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-    }
-    if (default_layer_state == (1U << 2)) {
-        gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-    }
+    keychron_os_led_process();
 }
 
 void suspend_power_down_kb(void) {

--- a/keyboards/keychron/c2_pro_8k/c2_pro_8k.c
+++ b/keyboards/keychron/c2_pro_8k/c2_pro_8k.c
@@ -26,7 +26,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_BASE_LAYER : WIN_BASE_LAYER));
     }
     return true;
 }
@@ -50,8 +50,10 @@ void keychron_task_kb(void) {
 
             if (!host_keyboard_led_state().caps_lock) gpio_write_pin(LED_CAPS_LOCK_PIN, !LED_PIN_ON_STATE);
             if (!host_keyboard_led_state().num_lock) gpio_write_pin(LED_NUM_LOCK_PIN, !LED_PIN_ON_STATE);
-            gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+
+#ifdef LED_OS_TIMEOUT
+            keychron_os_led_trigger();
+#endif
         } else {
             gpio_write_pin(LED_CAPS_LOCK_PIN, LED_PIN_ON_STATE);
             gpio_write_pin(LED_NUM_LOCK_PIN, LED_PIN_ON_STATE);
@@ -59,13 +61,7 @@ void keychron_task_kb(void) {
             gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
         }
     } else {
-        if (get_highest_layer(default_layer_state) == MAC_BASE_LAYER) {
-            gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-        } else {
-            gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-            gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-        }
+        keychron_os_led_process();
     }
 }
 

--- a/keyboards/keychron/c2_pro_v2/c2_pro_v2.c
+++ b/keyboards/keychron/c2_pro_v2/c2_pro_v2.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 #ifdef DIP_SWITCH_ENABLE
 bool dip_switch_update_kb(uint8_t index, bool active) {
@@ -22,7 +23,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_BASE_LAYER : WIN_BASE_LAYER));
     }
     return true;
 }
@@ -82,18 +83,15 @@ void keyboard_post_init_kb(void) {
     gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
     gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
 
+#ifdef LED_OS_TIMEOUT
+    keychron_os_led_trigger();
+#endif
+
     keyboard_post_init_user();
 }
 
 void housekeeping_task_kb(void) {
-    if (default_layer_state == (1U << 0)) {
-        gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-    }
-    if (default_layer_state == (1U << 2)) {
-        gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-    }
+    keychron_os_led_process();
 }
 
 void suspend_power_down_kb(void) {

--- a/keyboards/keychron/c3_pro/c3_pro.c
+++ b/keyboards/keychron/c3_pro/c3_pro.c
@@ -15,6 +15,7 @@
  */
 
 #include "c3_pro.h"
+#include "keychron_common.h"
 
 void keyboard_post_init_kb(void) {
     gpio_set_pin_output_push_pull(LED_MAC_OS_PIN);
@@ -22,18 +23,15 @@ void keyboard_post_init_kb(void) {
     gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
     gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
     
+#ifdef LED_OS_TIMEOUT
+    keychron_os_led_trigger();
+#endif
+
     keyboard_post_init_user();
 }
 
 void housekeeping_task_kb(void) {
-    if (get_highest_layer(default_layer_state) == 0) {
-        gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-    }
-    if (get_highest_layer(default_layer_state) == 2) {
-        gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-    }
+    keychron_os_led_process();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
@@ -81,11 +79,11 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 #endif
         case KC_OSSW:
             if (record->event.pressed) {
-                // Switches default layer between `MAC_BASE` and `WIN_BASE` (0 and 2)
-                if (get_highest_layer(default_layer_state) == 2 ) {
-                    set_single_persistent_default_layer(0);
+                // Switches default layer between `MAC_BASE_LAYER` and `WIN_BASE_LAYER`
+                if (get_highest_layer(default_layer_state) == WIN_BASE_LAYER ) {
+                    set_single_persistent_default_layer(MAC_BASE_LAYER);
                 } else {
-                    set_single_persistent_default_layer(2);
+                    set_single_persistent_default_layer(WIN_BASE_LAYER);
                 }
             }
             return false;

--- a/keyboards/keychron/c3_pro_8k/c3_pro_8k.c
+++ b/keyboards/keychron/c3_pro_8k/c3_pro_8k.c
@@ -29,17 +29,15 @@ void keyboard_post_init_kb(void) {
     gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
     gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
 
+#ifdef LED_OS_TIMEOUT
+    keychron_os_led_trigger();
+#endif
+
     keyboard_post_init_user();
 }
 
 void keychron_task_kb(void) {
-    if (get_highest_layer(default_layer_state) == MAC_BASE_LAYER) {
-        gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-    } else {
-        gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-        gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
-    }
+    keychron_os_led_process();
 }
 
 void suspend_power_down_keychron_kb(void) {

--- a/keyboards/keychron/common/keychron_common.c
+++ b/keyboards/keychron/common/keychron_common.c
@@ -388,3 +388,37 @@ bool led_update_kb(led_t led_state) {
     return res;
 }
 #endif
+
+#if defined(LED_MAC_OS_PIN) && defined(LED_WIN_OS_PIN)
+
+#ifdef LED_OS_TIMEOUT
+static layer_state_t prev_default_layer_state = 0;
+static uint32_t layer_switch_timer = 0;
+static bool layer_switch_timer_active = false;
+
+void keychron_os_led_trigger(void) {
+    layer_switch_timer = timer_read32();
+    layer_switch_timer_active = true;
+}
+#endif
+
+void keychron_os_led_process(void) {
+    bool is_mac = (get_highest_layer(default_layer_state) == MAC_BASE_LAYER);
+    bool led_active = true;
+
+#ifdef LED_OS_TIMEOUT
+    if (prev_default_layer_state != default_layer_state) {
+        prev_default_layer_state = default_layer_state;
+        keychron_os_led_trigger();
+    }
+
+    if (layer_switch_timer_active && timer_elapsed32(layer_switch_timer) >= LED_OS_TIMEOUT) {
+        layer_switch_timer_active = false;
+    }
+    led_active = layer_switch_timer_active;
+#endif
+
+    gpio_write_pin(LED_MAC_OS_PIN, (led_active && is_mac) ? LED_OS_PIN_ON_STATE : !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_WIN_OS_PIN, (led_active && !is_mac) ? LED_OS_PIN_ON_STATE : !LED_OS_PIN_ON_STATE);
+}
+#endif

--- a/keyboards/keychron/common/keychron_common.h
+++ b/keyboards/keychron/common/keychron_common.h
@@ -20,6 +20,14 @@
 #include <assert.h>
 #include "keycodes.h"
 
+#ifndef MAC_BASE_LAYER
+#define MAC_BASE_LAYER 0
+#endif
+
+#ifndef WIN_BASE_LAYER
+#define WIN_BASE_LAYER 2
+#endif
+
 #ifndef CUSTOM_KEYCODES_ENABLE
 // clang-format off
 enum {
@@ -141,6 +149,10 @@ typedef struct PACKED {
 } key_combination_t;
 
 void keychron_common_init(void);
+#if defined(LED_MAC_OS_PIN) && defined(LED_WIN_OS_PIN)
+void keychron_os_led_trigger(void);
+void keychron_os_led_process(void);
+#endif
 bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record);
 bool process_record_keychron(uint16_t keycode, keyrecord_t *record);
 void keychron_common_task(void);


### PR DESCRIPTION
Not sure if you're up for new features in this fork but I've refactored the OS LED functionality a bit and added support for `LED_OS_TIMEOUT` which turns off OS LEDs after the defined ms amount so that they're not constantly on.